### PR TITLE
fix default launch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ COPY . /catkin_ws
 WORKDIR /catkin_ws
 RUN apt-get update
 RUN apt-get install python3-pip -y
+RUN pip3 install --user grpcio grpcio-tools
 # TODO remove when it got fixed in rosdep
 RUN pip3 install --user cookiecutter
 RUN rosdep update

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ rocker --x11 --nvidia --oyr-run-arg "-p 50051 --name grpc_turtle" ros-grpc-turtl
 docker exec -it grpc_turtle bash -c '. devel/setup.bash && roslaunch test generate_grpc_server.launch && catkin_make'
 
 # run it
-docker exec -it grpc_turtle bash -c '. devel/setup.bash && roslaunch turtles_grpc grpc_server.launch'
+docker exec -it grpc_turtle bash -c '. devel/setup.bash && roslaunch turtles_grpc server.launch'
 
 # and now the grpc server should be running at localhost:50051 ready to operate the turtle ٩(^‿^)۶!
 ```


### PR DESCRIPTION
default launch was not working because python grcp package is not in dockerfile and the script had a different name